### PR TITLE
[JENKINS-54786] Launch command should include an env var for the name…

### DIFF
--- a/src/main/java/hudson/slaves/CommandLauncher.java
+++ b/src/main/java/hudson/slaves/CommandLauncher.java
@@ -130,6 +130,7 @@ public class CommandLauncher extends ComputerLauncher {
             pb.environment().put("WORKSPACE", StringUtils.defaultString(computer.getAbsoluteRemoteFs(), node.getRemoteFS())); //path for local slave log
 
             {// system defined variables
+                pb.environment().put("NODE_NAME", computer.getName());
                 String rootUrl = Jenkins.getInstance().getRootUrl();
                 if (rootUrl!=null) {
                     pb.environment().put("HUDSON_URL", rootUrl);    // for backward compatibility

--- a/src/test/java/hudson/slaves/CommandLauncherTest.java
+++ b/src/test/java/hudson/slaves/CommandLauncherTest.java
@@ -79,6 +79,7 @@ public class CommandLauncherTest {
         try {
             slave.toComputer().connect(false).get();
         } catch (Exception e) {
+            System.err.println("uninteresting error (not running an actual agent.jar): " + e);
         }
     }
 

--- a/src/test/java/hudson/slaves/CommandLauncherTest.java
+++ b/src/test/java/hudson/slaves/CommandLauncherTest.java
@@ -23,22 +23,22 @@
  */
 package hudson.slaves;
 
+import hudson.Functions;
+import hudson.model.Node;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import hudson.Functions;
-import hudson.model.Node;
-
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 public class CommandLauncherTest {
 
@@ -49,7 +49,7 @@ public class CommandLauncherTest {
     // TODO sometimes gets EOFException as in commandSucceedsWithoutChannel
     public void commandFails() throws Exception {
         assumeTrue(!Functions.isWindows());
-        DumbSlave slave = createSlave("false");
+        DumbSlave slave = createSlaveTimeout("false");
 
         String log = slave.toComputer().getLog();
         assertTrue(log, slave.toComputer().isOffline());
@@ -61,7 +61,7 @@ public class CommandLauncherTest {
     @Test
     public void commandSucceedsWithoutChannel() throws Exception {
         assumeTrue(!Functions.isWindows());
-        DumbSlave slave = createSlave("true");
+        DumbSlave slave = createSlaveTimeout("true");
 
         String log = slave.toComputer().getLog();
         assertTrue(log, slave.toComputer().isOffline());
@@ -84,6 +84,11 @@ public class CommandLauncherTest {
             );
             j.jenkins.addNode(slave);
         }
+        return slave;
+    }
+
+    public DumbSlave createSlaveTimeout(String command) throws Exception {
+        DumbSlave slave = createSlave(command);
 
         try {
             slave.toComputer().connect(false).get(1, TimeUnit.SECONDS);


### PR DESCRIPTION
… of the node

This is my conceptual fix for https://issues.jenkins-ci.org/browse/JENKINS-54786

Included tests for the other environment variables and my addition.

Note: due to the way the UI works, the environment variable is only practically available in a script/program, and not actually as part of the command.

To allow it (and other variables) to be used in the command itself will require considerably more work.