### PR TITLE
Re-enable automatic approval of launch command if configured by admin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
     </properties>
     <name>Command Agent Launcher Plugin</name>
     <description>Allows agents to be launched using a specified command.</description>
@@ -46,8 +46,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1382.v7d694476f340</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
+            <version>1172.v35f6a_0b_8207e</version><!-- TODO: Remove when version in BOM is at least that -->
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>

--- a/src/main/java/hudson/slaves/CommandConnector.java
+++ b/src/main/java/hudson/slaves/CommandConnector.java
@@ -29,6 +29,7 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import java.io.IOException;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.command_launcher.Messages;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
@@ -49,11 +50,11 @@ public class CommandConnector extends ComputerConnector {
     public CommandConnector(String command) {
         this.command = command;
         // TODO add withKey if we can determine the Cloud.name being configured
-        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser());
+        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser(), true);
     }
 
     private Object readResolve() {
-        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create());
+        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create(), true);
         return this;
     }
 
@@ -74,7 +75,7 @@ public class CommandConnector extends ComputerConnector {
             if (Util.fixEmptyAndTrim(value) == null) {
                 return FormValidation.error(Messages.CommandLauncher_NoLaunchCommand());
             } else {
-                return ScriptApproval.get().checking(value, SystemCommandLanguage.get());
+                return ScriptApproval.get().checking(value, SystemCommandLanguage.get(), Jenkins.get().hasPermission(Jenkins.ADMINISTER));
             }
         }
 

--- a/src/main/java/hudson/slaves/CommandConnector.java
+++ b/src/main/java/hudson/slaves/CommandConnector.java
@@ -23,13 +23,17 @@
  */
 package hudson.slaves;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import java.io.IOException;
-import jenkins.model.Jenkins;
+
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.command_launcher.Messages;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
@@ -37,6 +41,8 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.languages.SystemCommandLanguage;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Executes a program on the controller and expect that script to connect.
@@ -50,7 +56,7 @@ public class CommandConnector extends ComputerConnector {
     public CommandConnector(String command) {
         this.command = command;
         // TODO add withKey if we can determine the Cloud.name being configured
-        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser(), true);
+        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser(), Stapler.getCurrentRequest() == null);
     }
 
     private Object readResolve() {
@@ -67,15 +73,29 @@ public class CommandConnector extends ComputerConnector {
     @Extension @Symbol("command")
     public static class DescriptorImpl extends ComputerConnectorDescriptor {
         @Override
+        public ComputerConnector newInstance(@Nullable StaplerRequest req, @NonNull JSONObject formData) throws FormException {
+            CommandConnector instance = (CommandConnector) super.newInstance(req, formData);
+            if (formData.get("oldCommand") != null) {
+                String oldCommand = formData.getString("oldCommand");
+                boolean approveIfAdmin = !StringUtils.equals(oldCommand, instance.command);
+                if (approveIfAdmin) {
+                    ScriptApproval.get().configuring(instance.command, SystemCommandLanguage.get(),
+                            ApprovalContext.create().withCurrentUser(), true);
+                }
+            }
+            return instance;
+        }
+
+        @Override
         public String getDisplayName() {
             return Messages.CommandLauncher_displayName();
         }
 
-        public FormValidation doCheckCommand(@QueryParameter String value) {
+        public FormValidation doCheckCommand(@QueryParameter String value, @QueryParameter String oldCommand) {
             if (Util.fixEmptyAndTrim(value) == null) {
                 return FormValidation.error(Messages.CommandLauncher_NoLaunchCommand());
             } else {
-                return ScriptApproval.get().checking(value, SystemCommandLanguage.get(), Jenkins.get().hasPermission(Jenkins.ADMINISTER));
+                return ScriptApproval.get().checking(value, SystemCommandLanguage.get(), !StringUtils.equals(value, oldCommand));
             }
         }
 

--- a/src/main/java/hudson/slaves/CommandLauncher.java
+++ b/src/main/java/hudson/slaves/CommandLauncher.java
@@ -79,7 +79,7 @@ public class CommandLauncher extends ComputerLauncher {
         agentCommand = command;
         env = null;
         // TODO add withKey if we can determine the Slave.nodeName being configured
-        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser());
+        ScriptApproval.get().configuring(command, SystemCommandLanguage.get(), ApprovalContext.create().withCurrentUser(), true);
     }
 
     /** Constructor for programmatic use. Always approves the script.
@@ -102,7 +102,7 @@ public class CommandLauncher extends ComputerLauncher {
     }
     
     private Object readResolve() {
-        ScriptApproval.get().configuring(agentCommand, SystemCommandLanguage.get(), ApprovalContext.create());
+        ScriptApproval.get().configuring(agentCommand, SystemCommandLanguage.get(), ApprovalContext.create(), true);
         return this;
     }
 
@@ -228,7 +228,7 @@ public class CommandLauncher extends ComputerLauncher {
             if(Util.fixEmptyAndTrim(value)==null)
                 return FormValidation.error(org.jenkinsci.plugins.command_launcher.Messages.CommandLauncher_NoLaunchCommand());
             else
-                return ScriptApproval.get().checking(value, SystemCommandLanguage.get());
+                return ScriptApproval.get().checking(value, SystemCommandLanguage.get(), Jenkins.get().hasPermission(Jenkins.ADMINISTER));
         }
     }
 }

--- a/src/main/resources/hudson/slaves/CommandConnector/config.jelly
+++ b/src/main/resources/hudson/slaves/CommandConnector/config.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <input type="hidden" name="oldCommand" value="${instance.command}"/>
   <f:entry title="${%Launch command}" field="command">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/hudson/slaves/CommandLauncher/config.jelly
+++ b/src/main/resources/hudson/slaves/CommandLauncher/config.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <input type="hidden" name="oldCommand" value="${instance.command}"/>
   <f:entry title="${%Launch command}" field="command">
     <f:textbox />
   </f:entry>


### PR DESCRIPTION
Re-enable automatic approval of launch command if configured by administrator user. Related to the script-security hardening (https://github.com/jenkinsci/script-security-plugin/commit/f4c0bb9b58e105b4fc6b62be0f7f2daa46178190)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
