### PR TITLE
EOL JSR 305

### DIFF
--- a/src/test/java/hudson/slaves/CommandLauncher2Test.java
+++ b/src/test/java/hudson/slaves/CommandLauncher2Test.java
@@ -38,7 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import org.apache.tools.ant.filters.StringInputStream;
 import static org.hamcrest.Matchers.*;


### PR DESCRIPTION
Several years ago, Jenkins core switched from the abandoned JSR 305 annotations to SpotBugs annotations, but this plugin never caught up. This PR adapts this plugin to the common convention used in Jenkins core and the vast majority of other Jenkins plugins.