### PR TITLE
Refresh plugin for April 2023

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.4</version>
+    <version>1.6</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-buildPlugin(useContainerAgent: true,
-    configurations: [
-        [platform: 'linux', jdk: 11],
-        [platform: 'windows', jdk: 8],
-    ])
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.49</version>
+        <version>4.61</version>
         <relativePath />
     </parent>
     <artifactId>command-launcher</artifactId>
@@ -13,7 +13,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
     <name>Command Agent Launcher Plugin</name>
     <description>Allows agents to be launched using a specified command.</description>
@@ -46,8 +46,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2025.v816d28f1e04f</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This is required for https://github.com/jenkinsci/stapler/pull/452 so that tests continue passing in this plugin and in BOM.